### PR TITLE
Update branding and video stream configuration

### DIFF
--- a/camera.py
+++ b/camera.py
@@ -10,8 +10,8 @@ import numpy as np
 
 class VideoCamera(object):
     def __init__(self, flip = False, file_type  = ".jpg", photo_string= "stream_photo"):
-        # self.vs = PiVideoStream(resolution=(1920, 1080), framerate=30).start()
-        self.vs = PiVideoStream().start()
+        # self.vs = PiVideoStream().start()
+        self.vs = PiVideoStream(resolution=(1920, 1080), framerate=30).start()
         self.flip = flip # Flip frame vertically
         self.file_type = file_type # image type i.e. .jpg
         self.photo_string = photo_string # Name to save the photo

--- a/main.py
+++ b/main.py
@@ -14,7 +14,7 @@ app = Flask(__name__)
 
 @app.route('/')
 def index():
-    return render_template('index.html') #you can customze index.html here
+    return render_template('index.html') #you can customize index.html here
 
 def gen(camera):
     #get camera frame

--- a/pi_video_stream.py
+++ b/pi_video_stream.py
@@ -29,9 +29,8 @@ class PiVideoStream:
         self.camera = Picamera2()
 
         # Create a video configuration
-        # We use "main" for the primary stream and specify BGR888 format for OpenCV compatibility.
         config = self.camera.create_video_configuration(
-            main={"size": resolution, "format": "BGR888"},
+            main={"size": resolution, "format": "RGB888"},
             controls={"FrameRate": framerate}
         )
         self.camera.configure(config)

--- a/templates/index.html
+++ b/templates/index.html
@@ -137,7 +137,7 @@ body {
 </div>
 
   <div class="top-right-logo">
-  	<a></a>Raspberry Pi - Camera Stream</a>
+  	<a></a>Stream Atelier</a>
   </div>
 
 


### PR DESCRIPTION
- Change display text in `index.html` to "Stream Atelier".
- Update video stream format from `BGR888` to `RGB888` for compatibility.
- Adjust commented-out and active `PiVideoStream` initialization in `camera.py` to include resolution and framerate.
- Fix typo in `main.py` comment.